### PR TITLE
add missing bitsandbytes dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torchvision
 spacy>=3.6.0
 pillow>=10.0.1
 deepspeed>=0.11.0
+bitsandbytes


### PR DESCRIPTION
Or it will show error info when run `python cli_demo.py ...`.