### PR TITLE
remove fixed port

### DIFF
--- a/web_demo.py
+++ b/web_demo.py
@@ -202,7 +202,7 @@ def main(args):
         print(gr.__version__)
 
     demo.queue(concurrency_count=10)
-    demo.launch(server_port=7860)
+    demo.launch()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Please don't give a fixed port in gradio. This will make the env var of `GRADIO_SERVER_PORT` failed to change the port.

https://www.gradio.app/docs/interface:

![](https://github.com/THUDM/CogVLM/assets/661860/75025037-ae59-4404-9c1b-901c118c065a)
