### PR TITLE
Update description of the huggingface-version quantized model

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,12 @@ python cli_demo.py --from_pretrained cogvlm-chat-v1.1 --version chat --fp16 --qu
 For huggingface version:
 
 ```python
-tokenizer = LlamaTokenizer.from_pretrained('vicuna-7b-v1.5')
+tokenizer = LlamaTokenizer.from_pretrained('lmsys/vicuna-7b-v1.5')
     model = AutoModelForCausalLM.from_pretrained(
         'THUDM/cogvlm-chat-hf',
         load_in_4bit=True,
         trust_remote_code=True,
+        bnb_4bit_compute_dtype=torch.float16,
     ).eval()
 query = 'Describe this image in details.'
 image = Image.open('image-path').convert('RGB')


### PR DESCRIPTION
# What

* Update description of the huggingface-version quantized model on README

# Why

* I observed the following error and warning with the original code

```
OSError: vicuna-7b-v1.5 is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
If this is a private repository, make sure to pass a token having permission to this repo either by logging in with `huggingface-cli login` or by passing `token=<your_token>`
```

```
/opt/conda/lib/python3.10/site-packages/bitsandbytes/nn/modules.py:224: UserWarning: Input type into Linear4bit is torch.float16, but bnb_4bit_compute_type=torch.float32 (default). This will lead to slow inference or training speed.
  warnings.warn(f'Input type into Linear4bit is torch.float16, but bnb_4bit_compute_type=torch.float32 (default). This will lead to slow inference or training speed.')
```

