### PR TITLE
fix wrong apex help message

### DIFF
--- a/utils/models/eva_clip_L_hf.py
+++ b/utils/models/eva_clip_L_hf.py
@@ -679,7 +679,7 @@ try:
     from apex.normalization import FusedLayerNorm
 except:
     FusedLayerNorm = LayerNorm
-    print("Please 'pip install apex'")
+    print("Please build and install Nvidia apex package with option '--cuda_ext' according to https://github.com/NVIDIA/apex#from-source .")
 
 
 @dataclass


### PR DESCRIPTION
Nvidia apex package cannot be installed by pip, it should be compiled and installed from source.
