### PR TITLE
fix top_p warning when temperature is false

### DIFF
--- a/openai_demo/openai_api.py
+++ b/openai_demo/openai_api.py
@@ -322,7 +322,7 @@ def generate_stream_cogvlm(model: PreTrainedModel, tokenizer: PreTrainedTokenize
         "repetition_penalty": repetition_penalty,
         "max_new_tokens": max_new_tokens,
         "do_sample": True if temperature > 1e-5 else False,
-        "top_p": top_p,
+        "top_p": top_p if temperature > 1e-5 else 0,
         'streamer': streamer,
     }
     if temperature > 1e-5:


### PR DESCRIPTION
Error message: `do_sample` is set to `False`. However, `top_p` is set to `0.8` -- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `top_p`.