### PR TITLE
Add web_demo requirement jsonlines to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ sse-starlette>=1.8.2
 fastapi>=0.109.0
 httpx>=0.26.0
 uvicorn>=0.27.0
+jsonlines>=4.0.0


### PR DESCRIPTION
Requirement is not listed and web_demo throws an error about it when the user tries to run it.